### PR TITLE
Fix import path for eris

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ are also I2P labs projects.
  configured to connect and listen on I2P connections only. It can be used as
  a safe, easy to configure IRC client, or use it with the BRB IRC server for
  a selfhosted group chat. Powered by [Dispatch](https://github.com/khlieng/dispatch),
- [Eris](https://github.com/prologic/eris), and [sam-forwarder](https://github.com/eyedeekay/sam-forwarder.)
+ [Eris](https://git.mills.io/prologic/eris), and [sam-forwarder](https://github.com/eyedeekay/sam-forwarder.)
  * [Experimental I2P Jpackage Installers](i2p/) Jpackage is a tool for bundling
  Java software with all the runtime dependencies and a Java environment which are
  required to make them work. We may be able to use this to create easier-to-use

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ client, an IRC server, and a WebIRC service, all of which are automatically
 configured to connect and listen on I2P connections only. It can be used as
 a safe, easy to configure IRC client, or use it with the BRB IRC server for
 a selfhosted group chat. Powered by <a href="https://github.com/khlieng/dispatch">Dispatch</a>,
-<a href="https://github.com/prologic/eris">Eris</a>, and <a href="https://github.com/eyedeekay/sam-forwarder.">sam-forwarder</a></li>
+<a href="https://git.mills.io/prologic/eris">Eris</a>, and <a href="https://github.com/eyedeekay/sam-forwarder.">sam-forwarder</a></li>
 <li><a href="i2p/">Experimental I2P Jpackage Installers</a> Jpackage is a tool for bundling
 Java software with all the runtime dependencies and a Java environment which are
 required to make them work. We may be able to use this to create easier-to-use

--- a/ySidebar.md
+++ b/ySidebar.md
@@ -27,7 +27,7 @@ are also I2P labs projects.
  configured to connect and listen on I2P connections only. It can be used as
  a safe, easy to configure IRC client, or use it with the BRB IRC server for
  a selfhosted group chat. Powered by [Dispatch](https://github.com/khlieng/dispatch),
- [Eris](https://github.com/prologic/eris), and [sam-forwarder](https://github.com/eyedeekay/sam-forwarder.)
+ [Eris](https://git.mills.io/prologic/eris), and [sam-forwarder](https://github.com/eyedeekay/sam-forwarder.)
  * [Experimental I2P Jpackage Installers](i2p/) Jpackage is a tool for bundling
  Java software with all the runtime dependencies and a Java environment which are
  required to make them work. We may be able to use this to create easier-to-use


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/eris](https://git.mills.io/prologic/eris).

For details on why see: https://github.com/prologic

Thank you! 🙇